### PR TITLE
Add missing tailwind option in Phoenix instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ config :tailwind,
       --config=tailwind.config.js
       --input=css/app.css
       --output=../priv/static/assets/app.css
-    )
+    ),
+    cd: Path.expand("../assets", __DIR__)
   ]
 ```
 


### PR DESCRIPTION
Thank you for publishing this amazing package!

I tried following the **Adding to Phoenix** from the README and got stuck at the tailwind config step.

It says to add these options:

```elixir
config :tailwind,
  version: "3.0.7",
  default: [
    args: ~w(
      --config=tailwind.config.js
      --input=css/app.css
      --output=../priv/static/assets/app.css
    )
  ]
```

However this wasn't working for me with following error: 
> Specified input file css/app.css does not exist.

To get it to work I had to add `cd: Path.expand("../assets", __DIR__)` to the config, as stated in another section of the README.

This PR adds the missing option to the Phoenix instructions in the README.