### PR TITLE
Add Tailwind CSS directives to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,19 @@ configuration in your `config/dev.exs` and add:
 
 Note we are enabling the file system watcher.
 
-Finally, back in your `mix.exs`, make sure you have a `assets.deploy`
+Back in your `mix.exs`, make sure you have a `assets.deploy`
 alias for deployments, which will also use the `--minify` option:
 
 ```elixir
 "assets.deploy": ["tailwind default --minify", ..., "phx.digest"]
+```
+
+Finally, add the Tailwind directives to your `assets/app.css` file:
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 ```
 
 ## Tailwind Configuration


### PR DESCRIPTION
This might save some confusion? Took me a few minutes to realise this is part of the installation/setup.

It is mentioned in: https://tailwindcss.com/docs/installation, and could be relevant for the Phoenix section. 