### PR TITLE
Fixed broken link in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/phoenixframework/tailwind/actions/workflows/main.yml/badge.svg)](https://github.com/phoenixframework/tailwind/actions/workflows/main.yml)
 
 Mix tasks for installing and invoking [tailwindcss](https://tailwindcss.com) via the
-stand-alone [tailwindcss cli](https://github.com/tailwindlabs/tailwindcss-standalone)
+stand-alone [tailwindcss cli](https://github.com/tailwindlabs/tailwindcss/tree/master/standalone-cli)
 
 ## Installation
 


### PR DESCRIPTION
The link for the standalone cli currently points to https://github.com/tailwindlabs/tailwindcss-standalone but this page does not exist (I assume it was a separat project when the readme-page was written and just recently got merged into the main repo) so I changed it to https://github.com/tailwindlabs/tailwindcss/tree/master/standalone-cli which is the part of the repo containing the standalone cli. 