### PR TITLE
removed version duplication from moduledoc

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -13,7 +13,6 @@ defmodule Tailwind do
 
       config :tailwind,
         version: "#{@latest_version}",
-        version: "3.0.7",
         default: [
           args: ~w(
             --config=tailwind.config.js


### PR DESCRIPTION
Remove the version duplication from showing in the moduledoc which generates the following snippet in the docs:

```elixir
config :tailwind,
  version: "3.0.7",  # <---- dynamic from variable
  version: "3.0.7",  # <---- hardcoded
  default: [
    args: ~w(
      --config=tailwind.config.js
      --input=css/app.css
      --output=../priv/static/assets/app.css
    ),
    cd: Path.expand("../assets", __DIR__),
  ]
```

on [https://hexdocs.pm/tailwind/Tailwind.html](https://hexdocs.pm/tailwind/Tailwind.html)