### PR TITLE
Add linux arm64 target

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -242,6 +242,7 @@ defmodule Tailwind do
   end
 
   # Available targets:
+  #  tailwindcss-linux-arm64
   #  tailwindcss-linux-x64
   #  tailwindcss-macos-arm64
   #  tailwindcss-macos-x64
@@ -254,6 +255,7 @@ defmodule Tailwind do
       {{:win32, _}, _arch, 64} -> "windows-x64.exe"
       {{:unix, :darwin}, arch, 64} when arch in ~w(arm aarch64) -> "macos-arm64"
       {{:unix, :darwin}, "x86_64", 64} -> "macos-x64"
+      {{:unix, :linux}, "aarch64", 64} -> "linux-arm64"
       {{:unix, _osname}, arch, 64} when arch in ~w(x86_64 amd64) -> "linux-x64"
       {_os, _arch, _wordsize} -> raise "tailwind is not available for architecture: #{arch_str}"
     end


### PR DESCRIPTION
The Tailwind CLI version 3.0.8 added support for arm64 Linux. Just added a case for that in the installer. Seems to work fine for me!