### PR TITLE
Fixing issue #16 - https://github.com/phoenixframework/tailwind/issue…

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -222,23 +222,27 @@ defmodule Tailwind do
 
     File.mkdir_p!("assets")
 
-    File.write!(Path.expand("assets/tailwind.config.js"), """
-    // See the Tailwind configuration guide for advanced usage
-    // https://tailwindcss.com/docs/configuration
-    module.exports = {
-      content: [
-        './js/**/*.js',
-        '../lib/*_web.ex',
-        '../lib/*_web/**/*.*ex'
-      ],
-      theme: {
-        extend: {},
-      },
-      plugins: [
-        require('@tailwindcss/forms')
-      ]
-    }
-    """)
+    default_config_path = Path.expand("assets/tailwind.config.js")
+
+    unless File.exists?(default_config_path) do
+      File.write!(default_config_path, """
+      // See the Tailwind configuration guide for advanced usage
+      // https://tailwindcss.com/docs/configuration
+      module.exports = {
+        content: [
+          './js/**/*.js',
+          '../lib/*_web.ex',
+          '../lib/*_web/**/*.*ex'
+        ],
+        theme: {
+          extend: {},
+        },
+        plugins: [
+          require('@tailwindcss/forms')
+        ]
+      }
+      """)
+    end
   end
 
   # Available targets:

--- a/test/tailwind_test.exs
+++ b/test/tailwind_test.exs
@@ -10,6 +10,40 @@ defmodule TailwindTest do
     assert File.exists?("assets/tailwind.config.js")
   end
 
+  test "does not overwrite existing assets/tailwind.config.js" do
+    assert ExUnit.CaptureIO.capture_io(fn ->
+      assert Tailwind.run(:default, ["--help"]) == 0
+    end) =~ @version
+
+    contents = """
+      module.exports = {
+        content: [
+          './js/**/*.js',
+          '../lib/*_web.ex',
+          '../lib/*_web/**/*.*ex'
+        ],
+        theme: {
+          zIndex: {
+            '0': 0,
+            '10': 10,
+            '20': 20,
+            '30': 30,
+            '40': 40,
+            '50': 50,
+          },
+          extend: {},
+        },
+        plugins: [
+          require('@tailwindcss/forms')
+        ]
+      }
+    """
+
+    File.write!("assets/tailwind.config.js", contents)
+
+    assert File.read!("assets/tailwind.config.js") == contents
+  end
+
   test "run on profile" do
     assert ExUnit.CaptureIO.capture_io(fn ->
              assert Tailwind.run(:another, []) == 0


### PR DESCRIPTION
Small bugfix for issue #16.

If there is a file `assets/tailwind.config.js`, then `mix tailwind.install` will not overwrite it.

I considered adding additional configuration parameter to the task like `mix tailwind.install --override-config`, but I decided it might be a bit confusing to the user.

Open to any suggestions!