### PR TITLE
Bump tailwind to 3.0.12

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :tailwind,
-  version: "3.0.10",
+  version: "3.0.12",
   another: [
     args: ["--help"]
   ]

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -1,6 +1,6 @@
 defmodule Tailwind do
   # https://github.com/tailwindlabs/tailwindcss/releases
-  @latest_version "3.0.10"
+  @latest_version "3.0.12"
 
   @moduledoc """
   Tailwind is an installer and runner for [tailwind](https://tailwind.github.io).


### PR DESCRIPTION
This includes the standalone linux build (https://github.com/tailwindlabs/tailwindcss/pull/6914)