### PR TITLE
Fix CI / Require OTP 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - pair:
               elixir: '1.10'
-              otp: 21
+              otp: 22
           - pair:
               elixir: '1.12'
               otp: 24

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Tailwind.MixProject do
       app: :tailwind,
       version: @version,
       elixir: "~> 1.10",
+      otp: ">= 22.0",
       deps: deps(),
       description: "Mix tasks for installing and invoking tailwind",
       package: [

--- a/test/tailwind_test.exs
+++ b/test/tailwind_test.exs
@@ -56,14 +56,15 @@ defmodule TailwindTest do
 
     Mix.Task.rerun("tailwind.install")
 
-    expected_css = String.trim("""
-    @import "tailwindcss/base";
-    @import "tailwindcss/components";
-    @import "tailwindcss/utilities";
+    expected_css =
+      String.trim("""
+      @import "tailwindcss/base";
+      @import "tailwindcss/components";
+      @import "tailwindcss/utilities";
 
-    body {
-    }
-    """)
+      body {
+      }
+      """)
 
     assert String.trim(File.read!("assets/css/app.css")) == expected_css
 


### PR DESCRIPTION
Here we
  - Require OTP 22 (see below!)
  - Fix formatting on a file
  - Fix branch name for the CI run on master

## Why OTP 22?

What a delightful yakshave this was

It looks like `httpc` wont download tailwind releases on OTP 21! (I tested locally with 21.3.8.2)

```
Erlang/OTP 21 [erts-10.3.5.19] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe]

Interactive Elixir (1.10.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)>  {:ok, _} = Application.ensure_all_started(:inets)
{:ok, [:inets]}
iex(2)> {:ok, _} = Application.ensure_all_started(:ssl)
{:ok, [:crypto, :asn1, :public_key, :ssl]}
iex(3)> :httpc.request(:get, {'https://github.com/tailwindlabs/tailwindcss/releases/download/v3.0.12/tailwindcss-linux-arm64', []},[], [])
{:ok,
 {{'HTTP/1.1', 400, 'Bad Request'},
  [
    {'connection', 'keep-alive'},
    {'date', 'Fri, 07 Jan 2022 21:09:07 GMT'},
    {'via', '1.1 varnish'},
    {'accept-ranges', 'bytes'},
    {'content-length', '0'},
    {'x-github-backend', 'Kubernetes'},
    {'x-github-request-id', '6C94:3EB3:E04A1:653345:61D8ABF2'},
    {'x-served-by', 'cache-yyz4521-YYZ'},
    {'x-cache', 'MISS'},
    {'x-cache-hits', '0'},
    {'x-timer', 'S1641589747.989005,VS0,VE18'}
  ], []}}
iex(4)>
```

When I use OTP 22 the above works fine!

`https://github.com/tailwindlabs/tailwindcss/releases/download/v3.0.12/tailwindcss-linux-arm64` redirects to `https://objects.githubusercontent.com/....` which is a front for s3. Looks like there’s some bug with `httpc` malforming requests after redirects — the kinds of headers that we get back makes me think it’s messing up the Host header or SNI…

I looked through the release notes for `inets` and I can’t find a bug that would make sense here. 

I'm assuming it's not worth making a bug report for OTP since this is an issue in OTP 21 only afaik?
