### PR TITLE
chore: add the removal of the import in app.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ configuration in your `config/dev.exs` and add:
 
 Note we are enabling the file system watcher.
 
+Check you have correctly remove the `import "../css/app.css"` line  in your `assets/js/app.js`.
+
 Finally, back in your `mix.exs`, make sure you have a `assets.deploy`
 alias for deployments, which will also use the `--minify` option:
 


### PR DESCRIPTION
As I've mentioned in #22, if you forget to remove this line your assets deploy task does not work and your dev build contains warning.