### PR TITLE
Comment out @import directives

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -319,7 +319,9 @@ defmodule Tailwind do
       @import "tailwindcss/components";
       @import "tailwindcss/utilities";
 
-      #{String.replace(app_css, ~s|@import "./phoenix.css";\n|, "")}
+      #{String.replace(app_css,
+      ~r|(@import "./\w+.css";)\n|,
+      "/* Tailwind CLI does not support local @import; merge the file into app.css or see Tailwind documentation */\n/* \\1 */\n\n")}
       """)
     end
   end

--- a/test/tailwind_test.exs
+++ b/test/tailwind_test.exs
@@ -52,6 +52,7 @@ defmodule TailwindTest do
   test "install on existing app.css and app.js" do
     File.write!("assets/css/app.css", """
     @import "./phoenix.css";
+    @import "./custom.css";
     body {
     }
     """)
@@ -69,6 +70,12 @@ defmodule TailwindTest do
       @import "tailwindcss/base";
       @import "tailwindcss/components";
       @import "tailwindcss/utilities";
+
+      /* Tailwind CLI does not support local @import; merge the file into app.css or see Tailwind documentation */
+      /* @import "./phoenix.css"; */
+
+      /* Tailwind CLI does not support local @import; merge the file into app.css or see Tailwind documentation */
+      /* @import "./custom.css"; */
 
       body {
       }


### PR DESCRIPTION
Deleting the `@import "./phoenix.css";` rule is not clear if you have not used Tailwind CLI before. Since installing this package is backwards-incompatible in this sense, I think it would be clearer to just comment out those lines, especially since the application will now not be able to use the classes in `./phoenix.css`. The user will have a clearer understanding of what is going on, even later on, if they do not overlook the changes and commit them straight into the repo.

In comparison, the change to `assets/js/app.js` keeps the original behaviour for the application and is therefore not a "destructive" action.