### PR TITLE
Correct npm package name for tailwindcss on hexdoc

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -39,7 +39,7 @@ defmodule Tailwind do
 
   For instance, you can install `tailwind` globally with `npm`:
 
-      $ npm install -g tailwind
+      $ npm install -g tailwindcss
 
   On Unix, the executable will be at:
 


### PR DESCRIPTION
`npm -g tailwind` will install https://www.npmjs.com/package/tailwind
which is not actually the tailwindcss package

Note that I don't correct where the bin path example is, because it's os and npm specific thing that could be any location, plus the current path is already just example (not real) 