### PR TITLE
Override Tailwind platform target with the :tailwind config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ to the ones configured above. Note profiles must be configured in your
 `config/config.exs`, as `tailwind` runs without starting your application
 (and therefore it won't pick settings in `config/runtime.exs`).
 
+Some version of tailwind fail on M1 Silicon macs, you can override the targetted platform in your config like so:
+
+```elixir
+config :tailwind,
+  version: "3.0.10",
+  target: "macos-x64"
+  default: [
+    args: ~w(
+      --config=tailwind.config.js
+      --input=css/app.css
+      --output=../priv/static/assets/app.css
+    ),
+    cd: Path.expand("../assets", __DIR__)
+  ]
+```
+
 ## Adding to Phoenix
 
 To add `tailwind` to an application using Phoenix, you will need Phoenix v1.6+

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,6 @@ import Config
 
 config :tailwind,
   version: "3.0.12",
-  target: "macos-x64",
   another: [
     args: ["--help"]
   ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,7 @@ import Config
 
 config :tailwind,
   version: "3.0.12",
+  target: "macos-x64",
   another: [
     args: ["--help"]
   ]

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -108,22 +108,6 @@ defmodule Tailwind do
         :ok
     end
 
-    configured_optional_target = Application.get_env(:tailwind, :target)
-
-    @valid_config_targets
-    |> Enum.member?(configured_optional_target)
-    |> unless do
-      # Logger.warn("""
-      # #{configured_optional_target} is not one of the listed supported
-      # tailwind platforms. Choose from #{Enum.join(@valid_config_targets, ", ")}
-      # """)
-
-      raise ArgumentError, """
-      #{configured_optional_target} is not one of the listed supported
-      tailwind platforms. Choose from #{Enum.join(@valid_config_targets, ", ")}
-      """
-    end
-
     Supervisor.start_link([], strategy: :one_for_one)
   end
 


### PR DESCRIPTION
This change gives developers the ability to override the platform target of tailwind CLI. Developers can add a `:target` key on the config to override manually

This is to address issue #39.

After doing some digging and just testing the tailwind command line, the M1 release target is broken. After testing the regular mac osx distribution, it works just fine on my M1 Silicon. Therefore the logical option is to let developer override the tailwind target in the config.