### PR TITLE
Adds .ex files to Tailwind content config

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -233,6 +233,7 @@ defmodule Tailwind do
         content: [
           './js/**/*.js',
           '../lib/*_web.ex',
+          '../lib/*_web/**/*.ex',
           '../lib/*_web/**/*.*ex'
         ],
         theme: {


### PR DESCRIPTION
The `live_helpers.ex` helper which is automatically created when using the `mix phx.gen.live` generator was ignored by Tailwind, this change fixes this.

**EDIT:** Stupid autocorrection 😅