### PR TITLE
Add "skip-prepare" Option to Install

### DIFF
--- a/lib/mix/tasks/tailwind.install.ex
+++ b/lib/mix/tasks/tailwind.install.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Tailwind.Install do
   def run(args) do
     valid_options = [runtime_config: :boolean, if_missing: :boolean, skip_prepare: :boolean]
 
-    case OptionParser.parse_head!(args, strict: valid_options) do
+    case OptionParser.parse_head(args, strict: valid_options) do
       {opts, []} ->
         if opts[:runtime_config], do: Mix.Task.run("app.config")
 
@@ -40,14 +40,14 @@ defmodule Mix.Tasks.Tailwind.Install do
           |> Tailwind.install()
         end
 
-      {_, _} ->
+      {_, _, _} ->
         Mix.raise("""
-        Invalid arguments to tailwind.install, expected one of:
+        Invalid arguments to tailwind.install
 
-            mix tailwind.install
-            mix tailwind.install --runtime-config
-            mix tailwind.install --if-missing
-            mix tailwind.install --skip-prepare
+        usage: mix tailwind.install [--runtime-config] [--if-missing] [--skip-prepare]
+          --runtime-config: Tells the task runner to load the runtime mix config before installing
+          --if-missing: Detect if tailwind is installed first, then abort
+          --skip-prepare: Do not automatically modify assets/js/app.js or assets/css/app.css for tailwind
         """)
     end
   end

--- a/lib/mix/tasks/tailwind.install.ex
+++ b/lib/mix/tasks/tailwind.install.ex
@@ -26,7 +26,7 @@ defmodule Mix.Tasks.Tailwind.Install do
 
   @impl true
   def run(args) do
-    valid_options = [runtime_config: :boolean, if_missing: :boolean]
+    valid_options = [runtime_config: :boolean, if_missing: :boolean, skip_prepare: :boolean]
 
     case OptionParser.parse_head!(args, strict: valid_options) do
       {opts, []} ->
@@ -35,7 +35,9 @@ defmodule Mix.Tasks.Tailwind.Install do
         if opts[:if_missing] && latest_version?() do
           :ok
         else
-          Tailwind.install()
+          opts
+          |> Keyword.take([:skip_prepare])
+          |> Tailwind.install()
         end
 
       {_, _} ->
@@ -45,6 +47,7 @@ defmodule Mix.Tasks.Tailwind.Install do
             mix tailwind.install
             mix tailwind.install --runtime-config
             mix tailwind.install --if-missing
+            mix tailwind.install --skip-prepare
         """)
     end
   end

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -209,7 +209,7 @@ defmodule Tailwind do
   @doc """
   Installs tailwind with `configured_version/0`.
   """
-  def install do
+  def install(opts \\ []) do
     version = configured_version()
     name = "tailwindcss-#{target()}"
     url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v#{version}/#{name}"
@@ -220,10 +220,8 @@ defmodule Tailwind do
     File.write!(bin_path, binary, [:binary])
     File.chmod(bin_path, 0o755)
 
-    File.mkdir_p!("assets/css")
-
-    prepare_app_css()
-    prepare_app_js()
+    prepare_app_css(Keyword.get(opts, :skip_prepare, false))
+    prepare_app_js(Keyword.get(opts, :skip_prepare, false))
 
     unless File.exists?(tailwind_config_path) do
       File.write!(tailwind_config_path, """
@@ -310,7 +308,8 @@ defmodule Tailwind do
     end
   end
 
-  defp prepare_app_css do
+  defp prepare_app_css(false) do
+    File.mkdir_p!("assets/css")
     app_css = app_css()
 
     unless app_css =~ "tailwind" do
@@ -324,7 +323,9 @@ defmodule Tailwind do
     end
   end
 
-  defp prepare_app_js do
+  defp prepare_app_css(_), do: :ok
+
+  defp prepare_app_js(false) do
     case File.read("assets/js/app.js") do
       {:ok, app_js} ->
         File.write!("assets/js/app.js", String.replace(app_js, ~s|import "../css/app.css"\n|, ""))
@@ -333,6 +334,8 @@ defmodule Tailwind do
         :ok
     end
   end
+
+  defp prepare_app_js(_), do: :ok
 
   defp app_css do
     case File.read("assets/css/app.css") do


### PR DESCRIPTION
* This change adds a `--skip-prepare` option to the install mix task and passes an `opts` `Keyword` list to the install function for handling. If the skip option is true, the `prepare_app_css` and `prepare_app_js` functions will not be called.
* It also moves the creation of `assets/css` into `prepare_app_css` so that the folder is not created unless necessary
* It also updates the mix task to display some detail on the options in its usage statement, as well as to properly display the usage statement if an invalid usage is presented.

This fixes https://github.com/phoenixframework/tailwind/issues/44