### PR TITLE
tailwind 3.1.7 does not exist, plugin not required in top of generate…

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ directory, the OS environment, and default arguments to the
 
 ```elixir
 config :tailwind,
-  version: "3.1.7",
+  version: "3.1.6",
   default: [
     args: ~w(
       --config=tailwind.config.js
@@ -100,7 +100,7 @@ as our css entry point:
 
 ```elixir
 config :tailwind,
-  version: "3.1.7",
+  version: "3.1.6",
   default: [
     args: ~w(
       --config=tailwind.config.js
@@ -119,7 +119,7 @@ the web application's asset directory in the configuration:
 
 ```elixir
 config :tailwind,
-  version: "3.1.7",
+  version: "3.1.6",
   default: [
     args: ...,
     cd: Path.expand("../apps/<folder_ending_with_web>/assets", __DIR__)

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -1,6 +1,6 @@
 defmodule Tailwind do
   # https://github.com/tailwindlabs/tailwindcss/releases
-  @latest_version "3.1.0"
+  @latest_version "3.1.6"
 
   @moduledoc """
   Tailwind is an installer and runner for [tailwind](https://tailwindcss.com/).
@@ -136,7 +136,7 @@ defmodule Tailwind do
       unknown tailwind profile. Make sure the profile is defined in your config/config.exs file, such as:
 
           config :tailwind,
-            version: "3.1.0",
+            version: "3.1.6",
             #{profile}: [
               args: ~w(
                 --config=tailwind.config.js
@@ -241,6 +241,8 @@ defmodule Tailwind do
       File.write!(tailwind_config_path, """
       // See the Tailwind configuration guide for advanced usage
       // https://tailwindcss.com/docs/configuration
+      const plugin = require('tailwindcss/plugin')
+
       module.exports = {
         content: [
           './js/**/*.js',


### PR DESCRIPTION
…d config

Hit these issues when installing this for a new project. Tests still do not pass, even with these changes.

```
1) test updates on install (TailwindTest)
     test/tailwind_test.exs:33
     Assertion with == failed
     code:  assert Tailwind.run(:default, ["--help"]) == 0
     left:  137
     right: 0
     stacktrace:
       (ex_unit 1.13.4) lib/ex_unit/capture_io.ex:272: ExUnit.CaptureIO.do_capture_gl/2
       (ex_unit 1.13.4) lib/ex_unit/capture_io.ex:230: ExUnit.CaptureIO.do_with_io/3
       (ex_unit 1.13.4) lib/ex_unit/capture_io.ex:106: ExUnit.CaptureIO.capture_io/1
       test/tailwind_test.exs:37: (test)



  2) test run with pre-existing app.css (TailwindTest)
     test/tailwind_test.exs:27
     Assertion with == failed
     code:  assert Tailwind.run(:default, []) == 0
     left:  137
     right: 0
     stacktrace:
       (ex_unit 1.13.4) lib/ex_unit/capture_io.ex:272: ExUnit.CaptureIO.do_capture_gl/2
       (ex_unit 1.13.4) lib/ex_unit/capture_io.ex:230: ExUnit.CaptureIO.do_with_io/3
       (ex_unit 1.13.4) lib/ex_unit/capture_io.ex:106: ExUnit.CaptureIO.capture_io/1
       test/tailwind_test.exs:28: (test)

```