### PR TITLE
Update watcher documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For development, we want to enable watch mode. So find the `watchers`
 configuration in your `config/dev.exs` and add:
 
 ```elixir
-  tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
+  mix: ["tailwind", "default", "--watch", cd: Path.expand("..", __DIR__)]
 ```
 
 Note we are enabling the file system watcher.


### PR DESCRIPTION
Hello, I'm not a Phoenix/Elixir expert, but I couldn't make the watcher work according to the doc. I was getting an error like this:

> ** (Protocol.UndefinedError) protocol Enumerable not implemented for {Tailwind, :install_and_run, [:default, ["--watch"]]} of type Tuple

So I poked around and changed the config to look more like node/webpack and this version works. I thought I'd create a PR for others take a look at this...