### PR TITLE
Don't generate assets files when running install_and_run

### DIFF
--- a/lib/mix/tasks/tailwind.install.ex
+++ b/lib/mix/tasks/tailwind.install.ex
@@ -12,6 +12,9 @@ defmodule Mix.Tasks.Tailwind.Install do
 
       config :tailwind, :version, "#{Tailwind.latest_version()}"
 
+  It also writes to `assets/` files to enable tailwind if they
+  have not already been configured.
+
   ## Options
 
       * `--runtime-config` - load the runtime configuration
@@ -36,6 +39,7 @@ defmodule Mix.Tasks.Tailwind.Install do
           :ok
         else
           Tailwind.install()
+          Tailwind.configure_files()
         end
 
       {_, _} ->

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -212,7 +212,7 @@ defmodule Tailwind do
   """
   def install_and_run(profile, args) do
     unless File.exists?(bin_path()) do
-      install()
+      install_tailwind()
     end
 
     run(profile, args)
@@ -222,15 +222,9 @@ defmodule Tailwind do
   Installs tailwind with `configured_version/0`.
   """
   def install do
-    version = configured_version()
-    name = "tailwindcss-#{target()}"
-    url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v#{version}/#{name}"
-    bin_path = bin_path()
+    install_tailwind()
+
     tailwind_config_path = Path.expand("assets/tailwind.config.js")
-    binary = fetch_body!(url)
-    File.mkdir_p!(Path.dirname(bin_path))
-    File.write!(bin_path, binary, [:binary])
-    File.chmod(bin_path, 0o755)
 
     File.mkdir_p!("assets/css")
 
@@ -263,6 +257,17 @@ defmodule Tailwind do
       }
       """)
     end
+  end
+
+  defp install_tailwind do
+    version = configured_version()
+    name = "tailwindcss-#{target()}"
+    url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v#{version}/#{name}"
+    bin_path = bin_path()
+    binary = fetch_body!(url)
+    File.mkdir_p!(Path.dirname(bin_path))
+    File.write!(bin_path, binary, [:binary])
+    File.chmod(bin_path, 0o755)
   end
 
   # Available targets:

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -212,7 +212,7 @@ defmodule Tailwind do
   """
   def install_and_run(profile, args) do
     unless File.exists?(bin_path()) do
-      install_tailwind()
+      install()
     end
 
     run(profile, args)
@@ -222,44 +222,6 @@ defmodule Tailwind do
   Installs tailwind with `configured_version/0`.
   """
   def install do
-    install_tailwind()
-
-    tailwind_config_path = Path.expand("assets/tailwind.config.js")
-
-    File.mkdir_p!("assets/css")
-
-    prepare_app_css()
-    prepare_app_js()
-
-    unless File.exists?(tailwind_config_path) do
-      File.write!(tailwind_config_path, """
-      // See the Tailwind configuration guide for advanced usage
-      // https://tailwindcss.com/docs/configuration
-
-      let plugin = require('tailwindcss/plugin')
-
-      module.exports = {
-        content: [
-          './js/**/*.js',
-          '../lib/*_web.ex',
-          '../lib/*_web/**/*.*ex'
-        ],
-        theme: {
-          extend: {},
-        },
-        plugins: [
-          require('@tailwindcss/forms'),
-          plugin(({addVariant}) => addVariant('phx-no-feedback', ['&.phx-no-feedback', '.phx-no-feedback &'])),
-          plugin(({addVariant}) => addVariant('phx-click-loading', ['&.phx-click-loading', '.phx-click-loading &'])),
-          plugin(({addVariant}) => addVariant('phx-submit-loading', ['&.phx-submit-loading', '.phx-submit-loading &'])),
-          plugin(({addVariant}) => addVariant('phx-change-loading', ['&.phx-change-loading', '.phx-change-loading &']))
-        ]
-      }
-      """)
-    end
-  end
-
-  defp install_tailwind do
     version = configured_version()
     name = "tailwindcss-#{target()}"
     url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v#{version}/#{name}"
@@ -341,6 +303,45 @@ defmodule Tailwind do
 
   defp otp_version do
     :erlang.system_info(:otp_release) |> List.to_integer()
+  end
+
+  @doc """
+  Configures asset files
+  """
+  def configure_files do
+    tailwind_config_path = Path.expand("assets/tailwind.config.js")
+
+    File.mkdir_p!("assets/css")
+
+    prepare_app_css()
+    prepare_app_js()
+
+    unless File.exists?(tailwind_config_path) do
+      File.write!(tailwind_config_path, """
+      // See the Tailwind configuration guide for advanced usage
+      // https://tailwindcss.com/docs/configuration
+
+      let plugin = require('tailwindcss/plugin')
+
+      module.exports = {
+        content: [
+          './js/**/*.js',
+          '../lib/*_web.ex',
+          '../lib/*_web/**/*.*ex'
+        ],
+        theme: {
+          extend: {},
+        },
+        plugins: [
+          require('@tailwindcss/forms'),
+          plugin(({addVariant}) => addVariant('phx-no-feedback', ['&.phx-no-feedback', '.phx-no-feedback &'])),
+          plugin(({addVariant}) => addVariant('phx-click-loading', ['&.phx-click-loading', '.phx-click-loading &'])),
+          plugin(({addVariant}) => addVariant('phx-submit-loading', ['&.phx-submit-loading', '.phx-submit-loading &'])),
+          plugin(({addVariant}) => addVariant('phx-change-loading', ['&.phx-change-loading', '.phx-change-loading &']))
+        ]
+      }
+      """)
+    end
   end
 
   defp prepare_app_css do

--- a/test/tailwind_test.exs
+++ b/test/tailwind_test.exs
@@ -30,6 +30,15 @@ defmodule TailwindTest do
            end) =~ @version
   end
 
+  test "tailwind mix task" do
+    assert ExUnit.CaptureIO.capture_io(fn ->
+             Mix.Task.rerun("tailwind", ["default"])
+           end) =~ @version
+
+    refute File.exists?("assets/tailwind.config.js")
+    refute File.exists?("assets/css/app.css")
+  end
+
   test "updates on install" do
     Application.put_env(:tailwind, :version, "3.0.3")
     Mix.Task.rerun("tailwind.install", ["--if-missing"])


### PR DESCRIPTION
This resolves an issue of assets being generated when watcher is running.

In our use case we saw assets files being generated whenever we span up the app in local from scratch. This is because the watcher runs `Tailwind.install_and_run/2` that will not only install tailwind but also touch asset files if tailwind doesn't exist. This is a problem in umbrella apps, and any apps that deviates from the default phoenix css/js setup as discussed in #33.

I don't believe the intention is to write assets file if you don't explicitly use `tailwind.install` mix task so I've removed that step from `Tailwind.install_and_run/2`.