### PR TITLE
Use only TLS 1.2 on OTP vesions < 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v0.1.9
+  * Use only TLS 1.2 on OTP versions less than 25.
+
 ## v0.1.8 (2022-07-14)
   * Fix generated tailwind.config.js missing plugin reference
 

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -314,7 +314,8 @@ defmodule Tailwind do
         depth: 2,
         customize_hostname_check: [
           match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-        ]
+        ],
+        versions: protocol_versions()
       ]
     ]
 
@@ -327,6 +328,14 @@ defmodule Tailwind do
       other ->
         raise "couldn't fetch #{url}: #{inspect(other)}"
     end
+  end
+
+  defp protocol_versions do
+    if otp_version() < 25, do: [:"tlsv1.2"], else: [:"tlsv1.2", :"tlsv1.3"]
+  end
+
+  defp otp_version do
+    :erlang.system_info(:otp_release) |> List.to_integer()
   end
 
   defp prepare_app_css do


### PR DESCRIPTION
Closes #54

Before & after shell output:

```bash
tailwind on master $ mix test
==> castore
Compiling 1 file (.ex)
Generated castore app
==> tailwind
Compiling 3 files (.ex)
Generated tailwind app

16:23:50.872 [debug] Downloading tailwind from https://github.com/tailwindlabs/tailwindcss/releases/download/v3.1.6/tailwindcss-macos-x64

16:23:51.382 [notice] TLS :client: In state :hello_middlebox_assert at ssl_gen_statem.erl:736 generated CLIENT ALERT: Fatal - Unexpected Message
 - {:unexpected_msg, {:internal, {:encrypted_extensions, %{sni: {:sni, []}}}}}
** (RuntimeError) couldn't fetch https://github.com/tailwindlabs/tailwindcss/releases/download/v3.1.6/tailwindcss-macos-x64: {:error, {:failed_connect, [{:to_address, {'objects.githubusercontent.com', 443}}, {:inet, [:inet], {:tls_alert, {:unexpected_message, 'TLS client: In state hello_middlebox_assert at ssl_gen_statem.erl:736 generated CLIENT ALERT: Fatal - Unexpected Message\n {unexpected_msg,{internal,{encrypted_extensions,\#{sni => {sni,[]}}}}}'}}}]}}
    (tailwind 0.1.8) lib/tailwind.ex:328: Tailwind.fetch_body!/1
    (tailwind 0.1.8) lib/tailwind.ex:230: Tailwind.install/0
    (mix 1.13.4) lib/mix/task.ex:397: anonymous fn/3 in Mix.Task.run_task/3
    (mix 1.13.4) lib/mix/task.ex:455: Mix.Task.run_alias/5
    (mix 1.13.4) lib/mix/cli.ex:84: Mix.CLI.run_task/2

tailwind on master $ git checkout mc-tls
Switched to branch 'mc-tls'

tailwind on mc-tls $ mix test
Compiling 2 files (.ex)

16:24:06.127 [debug] Downloading tailwind from https://github.com/tailwindlabs/tailwindcss/releases/download/v3.1.6/tailwindcss-macos-x64

16:24:11.862 [debug] Downloading tailwind from https://github.com/tailwindlabs/tailwindcss/releases/download/v3.1.6/tailwindcss-macos-x64

16:24:16.242 [debug] Downloading tailwind from https://github.com/tailwindlabs/tailwindcss/releases/download/v3.1.6/tailwindcss-macos-x64
...
16:24:22.364 [debug] Downloading tailwind from https://github.com/tailwindlabs/tailwindcss/releases/download/v3.0.3/tailwindcss-macos-x64

16:24:27.914 [debug] Downloading tailwind from https://github.com/tailwindlabs/tailwindcss/releases/download/v3.1.6/tailwindcss-macos-x64
..

Finished in 21.9 seconds (21.9s async, 0.00s sync)
5 tests, 0 failures

Randomized with seed 815578

$
```

Related discussion:

- https://elixirforum.com/t/github-ci-down-is-it-working-for-you/49661