### PR TITLE
Reorganize and touch-up Adding to Phoenix section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ to the ones configured above. Note profiles must be configured in your
 ## Adding to Phoenix
 
 To add `tailwind` to an application using Phoenix, you will need Phoenix v1.6+
-and the following four steps.
+and the following steps.
 
 First add it as a dependency in your `mix.exs`:
 
@@ -91,6 +91,13 @@ def deps do
     {:tailwind, "~> 0.1.8", runtime: Mix.env() == :dev}
   ]
 end
+```
+
+Also, in `mix.exs`, add `tailwind` to the `assets.deploy`
+alias for deployments (with the `--minify` option):
+
+```elixir
+"assets.deploy": ["tailwind default --minify", ..., "phx.digest"]
 ```
 
 Now let's change `config/config.exs` to tell `tailwind` to use
@@ -135,15 +142,17 @@ configuration in your `config/dev.exs` and add:
 
 Note we are enabling the file system watcher.
 
-Check you have correctly removed the `import "../css/app.css"` line
-in your `assets/js/app.js`.
+Finally, run the command:
 
-Finally, back in your `mix.exs`, make sure you have a `assets.deploy`
-alias for deployments, which will also use the `--minify` option:
-
-```elixir
-"assets.deploy": ["tailwind default --minify", ..., "phx.digest"]
+```bash
+$ mix tailwind.install
 ```
+
+This command installs Tailwind and  updates your `assets/css/app.css`
+and `assets/js/app.js` with the necessary changes to start using Tailwind
+right away. It also generates a default configuration file called
+`assets/tailwind.config.js` for you. This is the file we referenced
+when we configured `tailwind` in `config/config.exs`.
 
 ## Tailwind Configuration
 


### PR DESCRIPTION
Hi! I just went through the process of installing `tailwind` in my Phoenix application, and I have a few changes to the README that might help future readers.

Summary of changes:
- Moved section on updating `assets.deploy` to be after adding the `tailwind` dependency in `mix.exs`. This streamlines the necessary changes so that the reader does not have to come back to `mix.exs` later.
- Instructed the user to run `mix tailwind.install` at the end. I explained what effects this command has on the files in the project.
-  Removed instructions to check `assets/js/app.js`. `mix tailwind.install` removes the line in question for you, so there's no need to check.
- Removed "four" from the number of steps. I think it's not necessary to list the number of steps since things can change and that number might not be updated. It might be five steps anyway if you include the one for umbrella projects.