### PR TITLE
Fix code signing issue on MacOS

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -229,6 +229,11 @@ defmodule Tailwind do
     tailwind_config_path = Path.expand("assets/tailwind.config.js")
     binary = fetch_body!(url)
     File.mkdir_p!(Path.dirname(bin_path))
+
+    if File.exists?(bin_path) do
+      File.rm!(bin_path)
+    end
+
     File.write!(bin_path, binary, [:binary])
     File.chmod(bin_path, 0o755)
 

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -230,6 +230,8 @@ defmodule Tailwind do
     binary = fetch_body!(url)
     File.mkdir_p!(Path.dirname(bin_path))
 
+    # MacOS doesn't recompute code signing information if a binary
+    # is overwritten with a new version, so we force creation of a new file
     if File.exists?(bin_path) do
       File.rm!(bin_path)
     end


### PR DESCRIPTION
This closes https://github.com/phoenixframework/tailwind/issues/39

The problem stems from MacOS associating signature information with the vnode, and it isn't recomputed if the file already exists, leading to a cryptic error if you upgrade tailwind and overwrite the binary.

The solution is to first delete the file, which seems to force recomputation of the signature since a new inode/vnode is created when you download the file again.

It's not the cleanest thing, but without this upgrading tailwind on MacOS leads to super cryptic errors.

More color on the issue here: https://stackoverflow.com/questions/67378106/mac-m1-cping-binary-over-another-results-in-crash