### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ lifecycle classes:
 * `phx-no-feedback` - applied when feedback should be hidden from the user
 * `phx-click-loading` - applied when an event is sent to the server on click while the client awaits the server response
 * `phx-submit-loading` - applied when a form is submitted while the client awaits the server response
-* `phx-submit-loading` - applied when a form input is changed while the client awaits the server response
+* `phx-change-loading` - applied when a form input is changed while the client awaits the server response
 
 Therefore, you may apply a variant, such as `phx-click-loading:animate-pulse` to customize tailwind classes
 when Phoenix LiveView classes are applied.


### PR DESCRIPTION
First of all, thanks for all the great tooling!  🙏

It looks like there was a copy/paste issue where the `phx-submit-loading` variant was listed twice and the 2nd occurrence should have been `phx-change-loading`.

