### PR TITLE
Support FreeBSD with bespoke upstream build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+* Add FreeBSD targets
+* Add armv7 targets
+* Support custom URLs for fetching prebuilt tailwind binaries
+
 ## v0.1.9 (2022-09-06)
 
 * Use only TLS 1.2 on OTP versions less than 25.

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -278,6 +278,8 @@ defmodule Tailwind do
   end
 
   # Available targets:
+  #  tailwindcss-freebsd-arm64
+  #  tailwindcss-freebsd-x64
   #  tailwindcss-linux-arm64
   #  tailwindcss-linux-x64
   #  tailwindcss-linux-armv7
@@ -292,6 +294,8 @@ defmodule Tailwind do
       {{:win32, _}, _arch, 64} -> "windows-x64.exe"
       {{:unix, :darwin}, arch, 64} when arch in ~w(arm aarch64) -> "macos-arm64"
       {{:unix, :darwin}, "x86_64", 64} -> "macos-x64"
+      {{:unix, :freebsd}, "aarch64", 64} -> "freebsd-arm64"
+      {{:unix, :freebsd}, "amd64", 64} -> "freebsd-x64"
       {{:unix, :linux}, "aarch64", 64} -> "linux-arm64"
       {{:unix, :linux}, "arm", 32} -> "linux-armv7"
       {{:unix, :linux}, "armv7" <> _, 32} -> "linux-armv7"


### PR DESCRIPTION
We can't use upstream tailwind FreeBSD packages, because the vercel/pkg tool that
tailwind relies on builds in github actions, which don't support FreeBSD. Thus
we build these externally, and need to make a few modifications to accommodate this.

- https://github.com/phoenixframework/tailwind/issues/49
- https://github.com/tailwindlabs/tailwindcss/discussions/7826

This is in "Works on my machine" mode presently; we could make further changes from here
if interested:

- add checksum support via mix config
- support arbitrary fetch URLs  https://github.com/phoenixframework/tailwind/issues/59

I will generate the build artifacts separately with verifiable checksum shortly, which
should improve the trust factor a bit.

Using https://builds.sr.ht/ and this manifest:

- https://gist.githubusercontent.com/dch/50431afa070772b6668132f739450e69/raw/62dea8184e28d9b0760896b0e77d536c565055b7/build.yml
- after about an hour we end up with https://builds.sr.ht/~dch/job/910662
- and [this artefact](https://patchouli.sr.ht/builds.sr.ht/artifacts/~dch/910662/0223ad33fd6373fe/tailwindcss-freebsd-x64)

This is now the artefact at https://people.freebsd.org/~dch/pub/tailwind/v3.2.4/tailwindcss-freebsd-x64 at least for the moment.

```
$ curl -#LO https://patchouli.sr.ht/builds.sr.ht/artifacts/~dch/910662/0223ad33fd6373fe/tailwindcss-freebsd-x64
############################################################################## 100.0%
$ l
total 4192
-rw-r--r--  1 dch  devel    44M Dec 23 21:15 tailwindcss-freebsd-x64
$ sha256 *
SHA256 (tailwindcss-freebsd-x64) = d71d4b4c8bf0e4d4bb590e286c892d3d7209640bac3c8c3cfb11aadc7b897694
$ sha512 *
SHA512 (tailwindcss-freebsd-x64) = a5a38f13cf405776f06164af4dbcf8bef9a3d8c256b8d3f90ae6a80ee9a2f0a13931138e86db083e7900664239c844124fc811f2f30ed98e69123905b6136693
```
Alternative approaches welcomed.