### PR TITLE
Add armv7l architecture

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -289,7 +289,7 @@ defmodule Tailwind do
       {{:unix, :darwin}, "x86_64", 64} -> "macos-x64"
       {{:unix, :linux}, "aarch64", 64} -> "linux-arm64"
       {{:unix, :linux}, "arm", 32} -> "linux-armv7"
-      {{:unix, :linux}, "armv7l", 32} -> "linux-armv7"
+      {{:unix, :linux}, "armv7" <> _, 32} -> "linux-armv7"
       {{:unix, _osname}, arch, 64} when arch in ~w(x86_64 amd64) -> "linux-x64"
       {_os, _arch, _wordsize} -> raise "tailwind is not available for architecture: #{arch_str}"
     end

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -289,6 +289,7 @@ defmodule Tailwind do
       {{:unix, :darwin}, "x86_64", 64} -> "macos-x64"
       {{:unix, :linux}, "aarch64", 64} -> "linux-arm64"
       {{:unix, :linux}, "arm", 32} -> "linux-armv7"
+      {{:unix, :linux}, "armv7l", 32} -> "linux-armv7"
       {{:unix, _osname}, arch, 64} when arch in ~w(x86_64 amd64) -> "linux-x64"
       {_os, _arch, _wordsize} -> raise "tailwind is not available for architecture: #{arch_str}"
     end


### PR DESCRIPTION
In follow-up of #70 

The original patch to support `arm7` will only work for the raspberry pi 3, but failed on my raspberry pi 4 running Raspbian 10 and uname -m reporting `armv7l`.

I've done a successful manual test with a Phoenix 1.7 (rc-0) project that was failing to build before on this device.