### PR TITLE
Separate tailwind install and assets configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ tailwind-*.tar
 /tmp/
 
 /assets/
+/custom/path

--- a/lib/mix/tasks/tailwind.install.ex
+++ b/lib/mix/tasks/tailwind.install.ex
@@ -53,6 +53,7 @@ defmodule Mix.Tasks.Tailwind.Install do
       :ok
     else
       Tailwind.install(base_url)
+      Tailwind.install_assets(:default)
     end
   end
 

--- a/test/tailwind_test.exs
+++ b/test/tailwind_test.exs
@@ -94,4 +94,13 @@ defmodule TailwindTest do
                "https://github.com/tailwindlabs/tailwindcss/releases/download/v$version/tailwindcss-$target"
              ])
   end
+
+  test "runs install with custom :cd" do
+    File.rm!(Tailwind.bin_path())
+    Application.put_env(:tailwind, :default, [cd: "custom/path/"])
+    Mix.Task.rerun("tailwind", ["default"])
+
+    assert File.exists?("custom/path/tailwind.config.js")
+    assert File.read!("custom/path/css/app.css") =~ "tailwind"
+  end
 end


### PR DESCRIPTION
This ensures that assets configuration happens in the specified cd opt if it's available, respecting umbrella folder structure