### PR TITLE
Ignore Browserslist warning.

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -174,9 +174,13 @@ defmodule Tailwind do
     config = config_for!(profile)
     args = config[:args] || []
 
+    env =
+      Keyword.get(config, :env, %{})
+      |> add_env_variable_to_ignore_browserslist_outdated_warning()
+
     opts = [
       cd: config[:cd] || File.cwd!(),
-      env: config[:env] || %{},
+      env: env,
       into: IO.stream(:stdio, :line),
       stderr_to_stdout: true
     ]
@@ -184,6 +188,10 @@ defmodule Tailwind do
     bin_path()
     |> System.cmd(args ++ extra_args, opts)
     |> elem(1)
+  end
+
+  defp add_env_variable_to_ignore_browserslist_outdated_warning(env) do
+    Enum.into(env, %{"BROWSERSLIST_IGNORE_OLD_DATA" => "1"})
   end
 
   @doc """

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -175,7 +175,8 @@ defmodule Tailwind do
     args = config[:args] || []
 
     env =
-      Keyword.get(config, :env, %{})
+      config
+      |> Keyword.get(:env, %{})
       |> add_env_variable_to_ignore_browserslist_outdated_warning()
 
     opts = [


### PR DESCRIPTION
There is some confusion about the warning that is shown from the Browserslist dependency in the tailwind CLI. See [here](https://elixirforum.com/t/running-phoenix-server-is-warning-from-npm-caniuse-lite-is-outdated/55570) and [here](https://elixir-lang.slack.com/archives/C03QQCV4H/p1682669271082769) for examples of such confusion.

The warning appears once the Browserslist package is more than six months old. The warning is particularly confusing because it proposes to run an npx command to resolve the issue. Because this is a packaged dependency of the tailwind CLI, this makes no sense. Ideally this would be fixed upstream (I personally think it's not a good idea to print such warnings in the first place), but I don't know how to go about that. See [these issues](https://github.com/search?q=org%3Abrowserslist+BROWSERSLIST_IGNORE_OLD_DATA&type=issues) for more background on this potential can of worms. This is an attempt to silence the warning for this particular use-case, which admittedly is less ideal, but gets the job done.

By setting the environment variable `BROWSERSLIST_IGNORE_OLD_DATA`, the warning about an outdated browserslist can be silenced.

The original warning for completeness:
```
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

This features is _not_ documented in the browserslist project. It's implemented [here](https://github.com/browserslist/browserslist/blob/main/node.js#L389).

--

Just as an aside: the same can be accomplished without any changes to this package, in user-config only. One can put this in `config.exs` instead:

```elixir
# Configure tailwind (the version is required)
config :tailwind,
  version: "3.2.4",
  default: [
    args: ~w(
      --config=tailwind.config.js
      --input=css/app.css
      --output=../priv/static/assets/app.css
    ),
    cd: Path.expand("../assets", __DIR__),
    env: %{"BROWSERSLIST_IGNORE_OLD_DATA" => "1"}
  ]
```
This has the same effect as it sets the same environment variable from the client config. It uses the `:env` config key (which is currently not documented).