### PR TITLE
Update tailwind.ex custom path instructions

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -24,7 +24,7 @@ defmodule Tailwind do
 
   ## Tailwind configuration
 
-  There are two global configurations for the tailwind application:
+  There are three global configurations for the tailwind application:
 
     * `:version` - the expected tailwind version
 
@@ -46,14 +46,13 @@ defmodule Tailwind do
 
   On Unix, the executable will be at:
 
-      NPM_ROOT/tailwind/node_modules/tailwind-TARGET/bin/tailwind
+      NPM_PREFIX/bin/tailwind
 
   On Windows, it will be at:
 
-      NPM_ROOT/tailwind/node_modules/tailwind-windows-(32|64)/tailwind.exe
+      NPM_PREFIX/tailwind.cmd
 
-  Where `NPM_ROOT` is the result of `npm root -g` and `TARGET` is your system
-  target architecture.
+  Where `NPM_PREFIX` is the result of `npm prefix -g`.
 
   Once you find the location of the executable, you can store it in a
   `MIX_TAILWIND_PATH` environment variable, which you can then read in


### PR DESCRIPTION
I ran the commands `npm install -g tailwindcss@3.3.5` and `npm install -g tailwindcss@2.2.16` in both Ubuntu and Windows with nodejs v18.18.2 and v20.8.0. None of those combinations generated the bin file in the documented path, but I did find them from the root `NPM_PREFIX` directory.

Could someone confirm this is the case on Mac Intel and Apple Silicon?

![image](https://github.com/phoenixframework/tailwind/assets/4416345/f84bbb19-86c1-4aef-a728-7455422279e7)

![image](https://github.com/phoenixframework/tailwind/assets/4416345/6712e2c7-16c5-4c89-934c-e67d6d04ad7e)