### PR TITLE
Fix the tailwind binary URL for FreeBSD on x64 (#49)

### DIFF
--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -252,7 +252,7 @@ defmodule Tailwind do
       {{:unix, :darwin}, arch, 64} when arch in ~w(arm aarch64) -> "macos-arm64"
       {{:unix, :darwin}, "x86_64", 64} -> "macos-x64"
       {{:unix, :freebsd}, "aarch64", 64} -> "freebsd-arm64"
-      {{:unix, :freebsd}, "amd64", 64} -> "freebsd-x64"
+      {{:unix, :freebsd}, arch, 64} when arch in ~w(x86_64 amd64) -> "freebsd-x64"
       {{:unix, :linux}, "aarch64", 64} -> "linux-arm64"
       {{:unix, :linux}, "arm", 32} -> "linux-armv7"
       {{:unix, :linux}, "armv7" <> _, 32} -> "linux-armv7"


### PR DESCRIPTION
`:erlang.system_info` on FreeBSD x64 may return different processor architecture strings depending on how it was installed - from ports, via asdf or using other methods.