### PR TITLE
In mix task `tailwind.install`, add instructions for using custom binary

### DIFF
--- a/lib/mix/tasks/tailwind.install.ex
+++ b/lib/mix/tasks/tailwind.install.ex
@@ -10,6 +10,15 @@ defmodule Mix.Tasks.Tailwind.Install do
 
       config :tailwind, :version, "#{Tailwind.latest_version()}"
 
+  To install the Tailwind binary from a custom URL (e.g. if your platform isn't
+  officially supported by Tailwind), you can supply a third party path to the
+  binary (beware that we cannot guarantee the compatibility of any third party
+  executable):
+
+  ```bash
+  $ mix tailwind.install https://people.freebsd.org/~dch/pub/tailwind/v3.2.6/tailwindcss-freebsd-x64
+  ```
+
   ## Options
 
       * `--runtime-config` - load the runtime configuration


### PR DESCRIPTION
Currently, these instructions are in the README, but they do not appear on HexDocs.

This commit basically just copies the line from the README into the doc page for `mix tailwind.install` so that the information is available in both places.