### PR TITLE
Feature: Don't check `version` if `path` is present

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :tailwind,
-  version: "3.2.7",
+  version: "3.4.6",
   another: [
     args: ["--help"]
   ]

--- a/lib/tailwind.ex
+++ b/lib/tailwind.ex
@@ -1,6 +1,6 @@
 defmodule Tailwind do
   # https://github.com/tailwindlabs/tailwindcss/releases
-  @latest_version "3.2.7"
+  @latest_version "3.4.6"
 
   @moduledoc """
   Tailwind is an installer and runner for [tailwind](https://tailwindcss.com/).
@@ -68,7 +68,7 @@ defmodule Tailwind do
 
   @doc false
   def start(_, _) do
-    unless Application.get_env(:tailwind, :version) do
+    unless Application.get_env(:tailwind, :version) or Application.get_env(:tailwind, :path) do
       Logger.warning("""
       tailwind version is not configured. Please set it in your config files:
 
@@ -103,7 +103,10 @@ defmodule Tailwind do
   Returns the configured tailwind version.
   """
   def configured_version do
-    Application.get_env(:tailwind, :version, latest_version())
+    default_version =
+      if Application.get_env(:tailwind, :path), do: bin_version(), else: latest_version()
+
+      Application.get_env(:tailwind, :version, default_version)
   end
 
   @doc """


### PR DESCRIPTION
I think checking the existence of the `version` param is redundant when using a path for `tailwind` binary. In this case, `tailwind` is probably managed with an external package manager (eg. `npm`).